### PR TITLE
allow optional passing of parent to source

### DIFF
--- a/src/main/matlab/+symphonyui/+app/DocumentationService.m
+++ b/src/main/matlab/+symphonyui/+app/DocumentationService.m
@@ -123,7 +123,11 @@ classdef DocumentationService < handle
                 error([description ' is not an available source description for the current parent type']);
             end
             constructor = str2func(description);
-            s = obj.session.getPersistor().addSource(parent, constructor());
+            if nargin(constructor) == 1
+                s = obj.session.getPersistor().addSource(parent, constructor(parent));
+            else
+                s = obj.session.getPersistor().addSource(parent, constructor());
+            end
             notify(obj, 'AddedSource', symphonyui.app.AppEventData(s));
         end
 


### PR DESCRIPTION
This is a simple pull request that extends the functionality of sources.

With this change, a source description constructor can optionally take the parent source as an input argument. This allows sources to modify themselves depending on the parent.

An example use case is to only allow creation of `Cell` sources under `Mouse` objects that have no default values. In the `Cell` constructor, one would check each property of the `mouse` object against an empty string (using `parent.getProperty()`), and throw an error if one is found.

This change should be fully backwards compatible, since the number of input arguments for the constructor is checked before passing the parent as an argument.